### PR TITLE
Fix CSS typo in effect.js

### DIFF
--- a/effect.js
+++ b/effect.js
@@ -37,7 +37,7 @@ $('document').ready(function(){
 		$('#bulb_green').addClass('bulb-glow-green-after');
 		$('#bulb_pink').addClass('bulb-glow-pink-after');
 		$('#bulb_orange').addClass('bulb-glow-orange-after');
-		$('body').css('backgroud-color','#FFF');
+		$('body').css('background-color','#FFF');
 		$('body').addClass('peach-after');
 		$(this).fadeOut('slow').delay(6000).promise().done(function(){
 			$('#bannar_coming').fadeIn('slow');


### PR DESCRIPTION
## Summary
- correct the `background-color` property in `effect.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6847c5b0fb0c8332967dbd75a689a235
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a typo in the background-color CSS property in effect.js to ensure the background color is applied correctly.

<!-- End of auto-generated description by cubic. -->

